### PR TITLE
feat: Chat e navegação de praia no mapa

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,5 +1,5 @@
 import { chatService, ConversationResponse } from '@/services/chat/chatService';
-import { useFocusEffect } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
@@ -14,6 +14,7 @@ import {
 
 type ConversationItemView = {
   id: string;
+  otherUserId: string;
   name: string;
   avatar: string;
   lastMessage: string;
@@ -67,6 +68,7 @@ function toConversationView(item: ConversationResponse): ConversationItemView {
 
   return {
     id: item.id,
+    otherUserId: item.otherUserId,
     name: item.otherUserName || fallbackName,
     avatar: item.otherUserAvatarUrl || FALLBACK_AVATAR,
     lastMessage: item.lastMessage?.content || 'Sem mensagens ainda',
@@ -75,9 +77,9 @@ function toConversationView(item: ConversationResponse): ConversationItemView {
   };
 }
 
-function ConversationCard({ item }: { item: ConversationItemView }) {
+function ConversationCard({ item, onPress }: { item: ConversationItemView; onPress: () => void }) {
   return (
-    <TouchableOpacity style={styles.conversationCard} activeOpacity={0.7}>
+    <TouchableOpacity style={styles.conversationCard} activeOpacity={0.7} onPress={onPress}>
       <Image source={{ uri: item.avatar }} style={styles.avatar} />
       <View style={styles.conversationContent}>
         <View style={styles.conversationHeader}>
@@ -103,6 +105,7 @@ function ConversationCard({ item }: { item: ConversationItemView }) {
 }
 
 export default function ChatScreen() {
+  const router = useRouter();
   const [conversations, setConversations] = useState<ConversationItemView[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -134,6 +137,21 @@ export default function ChatScreen() {
   const showCenteredLoader = loading && conversations.length === 0;
   const showRetry = !loading && !!error && conversations.length === 0;
 
+  const handleOpenConversation = useCallback(
+    (item: ConversationItemView) => {
+      router.push({
+        pathname: '/chat/[id]',
+        params: {
+          id: item.id,
+          name: item.name,
+          avatar: item.avatar,
+          otherUserId: item.otherUserId,
+        },
+      });
+    },
+    [router]
+  );
+
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
@@ -155,7 +173,9 @@ export default function ChatScreen() {
           <FlatList
             data={conversations}
             keyExtractor={(item) => item.id}
-            renderItem={({ item }) => <ConversationCard item={item} />}
+            renderItem={({ item }) => (
+              <ConversationCard item={item} onPress={() => handleOpenConversation(item)} />
+            )}
             showsVerticalScrollIndicator={false}
             ItemSeparatorComponent={() => <View style={styles.separator} />}
             refreshing={refreshing}

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -15,6 +15,7 @@ import {
     SymbolLayer
 } from '@maplibre/maplibre-react-native';
 import * as Location from 'expo-location';
+import { useRouter } from 'expo-router';
 import { GraduationCap, Locate, MapPin as MapPinIcon, Search, Store, Waves, Wrench } from 'lucide-react-native';
 import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { ActivityIndicator, Alert, Modal, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
@@ -122,6 +123,7 @@ function findNearestBeachId(
 }
 
 export default function MapScreen() {
+    const router = useRouter();
     const [allPins, setAllPins] = useState<MapPin[]>([]);
     const [beaches, setBeaches] = useState<BeachDTO[]>([]);
     const [activeFilters, setActiveFilters] = useState<SpotType[]>([...ALL_TYPES]);
@@ -329,6 +331,16 @@ export default function MapScreen() {
     const handleCloseSheet = useCallback(() => {
         setSelectedPinData(null);
     }, []);
+
+    const handleOpenBeachDetails = useCallback((pin: MapPin) => {
+        if (!pin.beachId) return;
+
+        setSelectedPinData(null);
+        router.push({
+            pathname: '/beach/[id]',
+            params: { id: String(pin.beachId) },
+        });
+    }, [router]);
 
     const normalizedSearch = searchText.trim().toLowerCase();
     const visiblePins = useMemo(() => {
@@ -543,7 +555,12 @@ export default function MapScreen() {
                     visible={selectedPinData !== null}
                     onClose={handleCloseSheet}
                 >
-                    {selectedPinData && <PinSheet pin={selectedPinData} />}
+                    {selectedPinData && (
+                        <PinSheet
+                            pin={selectedPinData}
+                            onOpenBeachDetails={handleOpenBeachDetails}
+                        />
+                    )}
                 </BottomSheet>
 
                 <Modal

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout() {
         <Stack.Screen name="register" options={{ headerShown: false }} />
         <Stack.Screen name="forgot-password" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="chat/[id]" options={{ title: 'Conversa' }} />
         <Stack.Screen name="beach/[id]" options={{ title: 'Praia' }} />
       </Stack>
       <StatusBar style="auto" />

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -1,0 +1,357 @@
+import { ChatMessageResponse, chatService } from '@/services/chat/chatService';
+import { userService } from '@/services/users/userService';
+import { useLocalSearchParams, useNavigation } from 'expo-router';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+function parseStringParam(value?: string | string[]): string {
+  if (!value) return '';
+  if (Array.isArray(value)) return value[0] || '';
+  return value;
+}
+
+function toTimeLabel(value?: string): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+
+  return date.toLocaleTimeString('pt-BR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function sortMessages(items: ChatMessageResponse[]): ChatMessageResponse[] {
+  return [...items].sort((a, b) => {
+    const first = new Date(a.createdAt).getTime();
+    const second = new Date(b.createdAt).getTime();
+
+    const safeFirst = Number.isNaN(first) ? 0 : first;
+    const safeSecond = Number.isNaN(second) ? 0 : second;
+    return safeFirst - safeSecond;
+  });
+}
+
+function MessageBubble({
+  message,
+  isMine,
+}: {
+  message: ChatMessageResponse;
+  isMine: boolean;
+}) {
+  return (
+    <View style={[styles.messageRow, isMine ? styles.messageRowMine : styles.messageRowOther]}>
+      <View style={[styles.messageBubble, isMine ? styles.messageBubbleMine : styles.messageBubbleOther]}>
+        <Text style={[styles.messageText, isMine && styles.messageTextMine]}>{message.content}</Text>
+        <Text style={[styles.messageTime, isMine && styles.messageTimeMine]}>{toTimeLabel(message.createdAt)}</Text>
+      </View>
+    </View>
+  );
+}
+
+export default function ChatConversationScreen() {
+  const params = useLocalSearchParams<{
+    id?: string | string[];
+    name?: string | string[];
+  }>();
+  const navigation = useNavigation();
+
+  const conversationId = useMemo(() => parseStringParam(params.id), [params.id]);
+  const conversationName = useMemo(() => parseStringParam(params.name), [params.name]);
+
+  const [messages, setMessages] = useState<ChatMessageResponse[]>([]);
+  const [currentUserId, setCurrentUserId] = useState<string>('');
+  const [draft, setDraft] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const listRef = useRef<FlatList<ChatMessageResponse>>(null);
+
+  useEffect(() => {
+    if (!navigation || !(navigation as any).setOptions) return;
+    (navigation as any).setOptions({
+      title: conversationName || 'Conversa',
+    });
+  }, [conversationName, navigation]);
+
+  const loadCurrentUser = useCallback(async () => {
+    try {
+      const me = await userService.getMyProfile();
+      setCurrentUserId(String(me.id));
+    } catch (e) {
+      console.error('Erro ao carregar usuario atual no chat:', e);
+      setCurrentUserId('');
+    }
+  }, []);
+
+  const loadMessages = useCallback(
+    async (isRefresh = false) => {
+      if (!conversationId) {
+        setError('Conversa invalida.');
+        setLoading(false);
+        setRefreshing(false);
+        return;
+      }
+
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
+
+      try {
+        setError(null);
+        const response = await chatService.getMessages(conversationId, 0, 50);
+        setMessages(sortMessages(response));
+      } catch (e) {
+        console.error('Erro ao carregar mensagens:', e);
+        setError('Nao foi possivel carregar as mensagens desta conversa.');
+      } finally {
+        if (isRefresh) setRefreshing(false);
+        else setLoading(false);
+      }
+    },
+    [conversationId]
+  );
+
+  useEffect(() => {
+    loadCurrentUser();
+  }, [loadCurrentUser]);
+
+  useEffect(() => {
+    loadMessages();
+  }, [loadMessages]);
+
+  useEffect(() => {
+    if (messages.length === 0) return;
+    listRef.current?.scrollToEnd({ animated: true });
+  }, [messages.length]);
+
+  const handleSend = useCallback(async () => {
+    if (!conversationId) return;
+
+    const content = draft.trim();
+    if (!content) return;
+
+    setSending(true);
+    try {
+      const sentMessage = await chatService.sendMessage(conversationId, content);
+      setMessages((prev) => sortMessages([...prev, sentMessage]));
+      setDraft('');
+    } catch (e) {
+      console.error('Erro ao enviar mensagem:', e);
+      setError('Nao foi possivel enviar sua mensagem agora.');
+    } finally {
+      setSending(false);
+    }
+  }, [conversationId, draft]);
+
+  const isInitialError = !!error && !loading && messages.length === 0;
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+      >
+        {loading && messages.length === 0 ? (
+          <View style={styles.centerState}>
+            <ActivityIndicator size="large" color="#5C9DB8" />
+            <Text style={styles.centerStateText}>Carregando mensagens...</Text>
+          </View>
+        ) : isInitialError ? (
+          <View style={styles.centerState}>
+            <Text style={styles.centerStateText}>{error}</Text>
+            <TouchableOpacity style={styles.retryButton} onPress={() => loadMessages()}>
+              <Text style={styles.retryButtonText}>Tentar novamente</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <FlatList
+            ref={listRef}
+            data={messages}
+            keyExtractor={(item, index) => item.id || `${item.createdAt}-${index}`}
+            renderItem={({ item }) => (
+              <MessageBubble message={item} isMine={!!currentUserId && String(item.senderId) === currentUserId} />
+            )}
+            contentContainerStyle={[
+              styles.listContent,
+              messages.length === 0 && styles.listContentEmpty,
+            ]}
+            showsVerticalScrollIndicator={false}
+            refreshing={refreshing}
+            onRefresh={() => loadMessages(true)}
+            ListEmptyComponent={
+              <View style={styles.emptyStateContainer}>
+                <Text style={styles.emptyStateText}>Nenhuma mensagem ainda. Comece a conversa.</Text>
+              </View>
+            }
+          />
+        )}
+
+        <View style={styles.composerContainer}>
+          <TextInput
+            value={draft}
+            onChangeText={setDraft}
+            style={styles.input}
+            placeholder="Digite uma mensagem..."
+            placeholderTextColor="#8B8B8B"
+            multiline
+          />
+          <TouchableOpacity
+            style={[styles.sendButton, (sending || !draft.trim()) && styles.sendButtonDisabled]}
+            onPress={handleSend}
+            disabled={sending || !draft.trim()}
+          >
+            <Text style={styles.sendButtonText}>{sending ? 'Enviando...' : 'Enviar'}</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#F6F4EB',
+  },
+  flex: {
+    flex: 1,
+  },
+  centerState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  centerStateText: {
+    color: '#5C9DB8',
+    fontSize: 14,
+    textAlign: 'center',
+  },
+  retryButton: {
+    backgroundColor: '#5C9DB8',
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  retryButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  listContent: {
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 16,
+    gap: 8,
+  },
+  listContentEmpty: {
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+  emptyStateContainer: {
+    alignItems: 'center',
+  },
+  emptyStateText: {
+    fontSize: 14,
+    color: '#5C9DB8',
+    textAlign: 'center',
+  },
+  messageRow: {
+    width: '100%',
+    marginBottom: 8,
+  },
+  messageRowMine: {
+    alignItems: 'flex-end',
+  },
+  messageRowOther: {
+    alignItems: 'flex-start',
+  },
+  messageBubble: {
+    maxWidth: '82%',
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  messageBubbleMine: {
+    backgroundColor: '#5C9DB8',
+    borderTopRightRadius: 6,
+  },
+  messageBubbleOther: {
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: '#E2DEC3',
+    borderTopLeftRadius: 6,
+  },
+  messageText: {
+    fontSize: 14,
+    color: '#1F4A63',
+    lineHeight: 20,
+  },
+  messageTextMine: {
+    color: '#FFFFFF',
+  },
+  messageTime: {
+    marginTop: 6,
+    fontSize: 11,
+    color: '#6B7280',
+    textAlign: 'right',
+  },
+  messageTimeMine: {
+    color: '#E5F0F5',
+  },
+  composerContainer: {
+    borderTopWidth: 1,
+    borderTopColor: '#E2DEC3',
+    backgroundColor: '#F6F4EB',
+    paddingHorizontal: 14,
+    paddingTop: 10,
+    paddingBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 10,
+  },
+  input: {
+    flex: 1,
+    minHeight: 44,
+    maxHeight: 120,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#D7D2B6',
+    backgroundColor: '#FFFFFF',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: '#1F4A63',
+    fontSize: 14,
+    textAlignVertical: 'top',
+  },
+  sendButton: {
+    backgroundColor: '#5C9DB8',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    minWidth: 74,
+    alignItems: 'center',
+  },
+  sendButtonDisabled: {
+    opacity: 0.6,
+  },
+  sendButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+    fontSize: 13,
+  },
+});

--- a/services/__tests__/chatService.integration.test.ts
+++ b/services/__tests__/chatService.integration.test.ts
@@ -26,6 +26,19 @@ describe('chatService integration (mock data + real HTTP call)', () => {
     await expect(chatService.getMyConversations()).resolves.toEqual(payload);
   });
 
+  test('getMyConversations deve aceitar resposta paginada', async () => {
+    const payload = [{ id: 'c2', group: false }];
+    server.setRoutes([
+      {
+        method: 'GET',
+        path: '/api/chat/conversations',
+        response: { status: 200, body: { content: payload } },
+      },
+    ]);
+
+    await expect(chatService.getMyConversations()).resolves.toEqual(payload);
+  });
+
   test('createOrGetDM deve retornar conversationId quando API mandar objeto', async () => {
     server.setRoutes([
       {
@@ -63,6 +76,19 @@ describe('chatService integration (mock data + real HTTP call)', () => {
     ]);
 
     await expect(chatService.getMessages('conv-1', 2, 15)).resolves.toEqual(payload);
+  });
+
+  test('getMessages deve aceitar resposta paginada', async () => {
+    const payload = [{ id: 'm9', content: 'Linha perfeita hoje' }];
+    server.setRoutes([
+      {
+        method: 'GET',
+        path: '/api/chat/conversations/conv-9/messages',
+        response: { status: 200, body: { content: payload } },
+      },
+    ]);
+
+    await expect(chatService.getMessages('conv-9')).resolves.toEqual(payload);
   });
 
   test('sendMessage deve consumir POST /api/chat/conversations/{id}/messages', async () => {

--- a/services/chat/chatService.ts
+++ b/services/chat/chatService.ts
@@ -1,5 +1,17 @@
 import api from '../api';
 
+interface PageResponse<T> {
+  content?: T[];
+}
+
+function normalizeList<T>(raw: unknown): T[] {
+  if (Array.isArray(raw)) return raw as T[];
+  if (raw && typeof raw === 'object' && Array.isArray((raw as PageResponse<T>).content)) {
+    return (raw as PageResponse<T>).content as T[];
+  }
+  return [];
+}
+
 export interface ChatMessageResponse {
   id: string;
   conversationId: string;
@@ -28,14 +40,27 @@ export const chatService = {
   // Inbox - Listar conversas ativas
   getMyConversations: async (): Promise<ConversationResponse[]> => {
     const response = await api.get('/api/chat/conversations');
-    return response.data;
+    return normalizeList<ConversationResponse>(response.data);
   },
 
   // Iniciar ou pegar DM existente com outro usuário
   createOrGetDM: async (otherUserId: string): Promise<string> => {
-    // Retorna o conversationId (string) que a API devolve
     const response = await api.post('/api/chat/dm', { otherUserId });
-    return response.data.conversationId || response.data;
+    const data = response.data as unknown;
+
+    if (typeof data === 'string') {
+      return data;
+    }
+
+    if (data && typeof data === 'object') {
+      const payload = data as { conversationId?: string | number; id?: string | number };
+      const idCandidate = payload.conversationId ?? payload.id;
+      if (idCandidate !== undefined && idCandidate !== null) {
+        return String(idCandidate);
+      }
+    }
+
+    throw new Error('Resposta inesperada ao criar conversa');
   },
 
   // Pegar mensagens de uma conversa
@@ -43,7 +68,7 @@ export const chatService = {
     const response = await api.get(`/api/chat/conversations/${conversationId}/messages`, {
       params: { page, size },
     });
-    return response.data;
+    return normalizeList<ChatMessageResponse>(response.data);
   },
 
   // Enviar Mensagem (via HTTP, antes do WebSockets)


### PR DESCRIPTION
Implementa fluxo de chat no mobile (lista, abertura de conversa e envio) e adiciona navegação do mapa para abrir praia singular ao selecionar pin. Inclui ajustes no chatService e testes de integração. Closes #21 e #77.

